### PR TITLE
TypeError $video[]

### DIFF
--- a/app/site/site.php
+++ b/app/site/site.php
@@ -345,7 +345,7 @@
     $koken_key = Shutter::get_encryption_key();
     $video = Koken::api('/content/types:video/limit:1/visibility:any/token:' . $koken_key);
 
-    Koken::$has_video = count($video['content']) > 0;
+    Koken::$has_video = count((array)$video['content']) > 0;
 
     if (!is_array($site_api)) {
         die(file_get_contents(Koken::$fallback_path . $ds . 'error' . $ds . 'api.html'));


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /web/app/site/site.php:348
Stack trace:
#0 /web/index.php(5): require()
#1 {main}
  thrown in /web/app/site/site.php on line 348
```