### PR TITLE
Used relative URLs for admin images for subdirectory installs

### DIFF
--- a/admin/templates/app.tmpl.html
+++ b/admin/templates/app.tmpl.html
@@ -18,7 +18,7 @@
 
   			<div class="hoffx">
 
-				<div id="console-logo"><img src="/admin/images/koken_logo.svg" height="38" width="38" /></div>
+				<div id="console-logo"><img src="images/koken_logo.svg" height="38" width="38" /></div>
 
 				<nav id="main-nav">
 	    			<ul>
@@ -187,7 +187,7 @@
 <script id="about_modal" type="text/html">
 	<div class="modal-outer" style="width:290px;text-align:center;">
 		<div class="wrap">
-			<p style="margin-bottom:20px;"><img src="/admin/images/koken_logo.svg" width="71" height="71" /></p>
+			<p style="margin-bottom:20px;"><img src="images/koken_logo.svg" width="71" height="71" /></p>
 			<p style="margin-bottom:20px;"><a href="http://help.koken.me/customer/portal/articles/848339-release-notes" title="Release notes" onclick="return !window.open(this.href);">Version <span data-bind="text: system.version"></span></a></p>
 			<p style="margin-bottom:10px;font-size:11px;"><a href="http://koken.me/eula.html" title="End user license agreement" onclick="return !window.open(this.href);" >License agreement</a> / <a href="http://koken.me/privacy.html" title="Privacy policy" onclick="return !window.open(this.href);">Privacy policy</a></p>
 			&copy; 2013-<span data-bind="text: (new Date()).getFullYear().toString().substring(3)"></span> Koken
@@ -215,7 +215,7 @@
 			<div class="bounds">
 				<a class="modal-close" href="#" title="Close tour"></a>
 				<div class="head-wrap">
-					<img src="/admin/images/koken_logo.svg" width="71" height="71" />
+					<img src="images/koken_logo.svg" width="71" height="71" />
 					<div class="copy">
 						<h1>Welcome to Koken</h1>
 						<p>This tour covers all the basics of using Koken in less than a minute.</p>
@@ -227,7 +227,7 @@
 						<div class="tour-bttn prev"><span></span></div>
 						<div id="tour-library" class="tour-current">
 							<div class="img">
-								<img src="/admin/images/tour-library.jpg" />
+								<img src="images/tour-library.jpg" />
 							</div>
 							<div class="copy">
 								<h2>Library</h2>
@@ -241,7 +241,7 @@
 						</div>
 						<div id="tour-text">
 							<div class="img">
-								<img src="/admin/images/tour-text.png" />
+								<img src="images/tour-text.png" />
 							</div>
 							<div class="copy">
 								<h2>Text</h2>
@@ -258,7 +258,7 @@
 						</div>
 						<div id="tour-site">
 							<div class="img">
-								<img src="/admin/images/tour-site.jpg" />
+								<img src="images/tour-site.jpg" />
 							</div>
 							<div class="copy">
 								<h2>Site</h2>
@@ -272,7 +272,7 @@
 						</div>
 						<div id="tour-store">
 							<div class="img">
-								<img src="/admin/images/tour-store.jpg" />
+								<img src="images/tour-store.jpg" />
 							</div>
 							<div class="copy">
 								<h2>Store</h2>


### PR DESCRIPTION
When Koken is installed within a subdirectory, some image requests within the admin fail due to use of an absolute URL.

In this PR I've changed them to use relative URLs, matching other assets in the admin and to better support installation in a subdirectory.