### PR TITLE
Fix album set typing and clean API output buffers

### DIFF
--- a/app/application/controllers/albums.php
+++ b/app/application/controllers/albums.php
@@ -92,11 +92,14 @@ class Albums extends Koken_Controller
                 $levels['_' . $album->level] = [];
             }
 
-            $type = match ($album->album_type) {
+            $type = match ((int)$album->album_type) {
                 2 => 'set',
                 1 => 'smart',
                 default => 'standard',
             };
+            $arr['album_type'] = $type;
+            $arr['type'] = $type; 
+
 
             $arr = array(
                 'id' => $album->id,

--- a/app/application/core/Koken_Controller.php
+++ b/app/application/core/Koken_Controller.php
@@ -329,6 +329,9 @@ class Koken_Controller extends CI_Controller
     // Ignore $data, it will always be empty. Use our response_data var instead
     public function _output($data, $code = 200)
     {
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
         switch ($this->format) {
             // TODO: Other formats (XML, ATOM, Media RSS)?
             case 'php':

--- a/app/application/models/album.php
+++ b/app/application/models/album.php
@@ -1138,11 +1138,13 @@ Q;
         $data['__koken__'] = 'album';
 
         if (array_key_exists('album_type', $data)) {
-            $data['album_type'] = match ($data['album_type']) {
+            $mapped = match ((int)$data['album_type']) {
                 2 => 'set',
                 1 => 'smart',
                 default => 'standard',
             };
+            $data['album_type'] = $mapped;
+            $data['type'] = $mapped;   // alias pour l’UI
         }
 
         if ($this->album_type == 2) {


### PR DESCRIPTION
Fixes the bug: in the admin panel, all albums appear like albums, whereas there should appear as 'sets'